### PR TITLE
improve flexibility in Orchestra\Html\HtmlBuilder

### DIFF
--- a/src/Orchestra/Html/HtmlBuilder.php
+++ b/src/Orchestra/Html/HtmlBuilder.php
@@ -96,31 +96,6 @@ class HtmlBuilder extends \Illuminate\Html\HtmlBuilder {
 	}
 	
 	/**
-	 * Generate a link to a JavaScript file.
-	 *
-	 * @param  string  $url
-	 * @param  array   $attributes
-	 * @return \Orchestra\Support\Expression
-	 */
-	public function script($url, $attributes = array())
-	{
-		return $this->raw(parent::script($url, $attributes));
-	}
-	
-	
-	/**
-	 * Generate a link to a CSS file.
-	 *
-	 * @param  string  $url
-	 * @param  array   $attributes
-	 * @return \Orchestra\Support\Expression
-	 */
-	public function style($url, $attributes = array())
-	{
-		return $this->raw(parent::style($url, $attributes));
-	}
-	
-	/**
 	 * Generate an HTML image element.
 	 *
 	 * @param  string  $url
@@ -195,11 +170,9 @@ class HtmlBuilder extends \Illuminate\Html\HtmlBuilder {
 	 */
 	public function __call($method, $parameters)
 	{
-		$value = parent::__call($method, $parameters);
+		$value = call_user_func_array(array($this, $method), $parameters);
 		
-		if(is_string($value)) {
-			return $this->raw($value);
-		}
+		if(is_string($value)) return $this->raw($value);
 		
 		return $value;
 	}


### PR DESCRIPTION
## Its more flexibility & easy this way.

No more:

``` php
echo HTML::link('foo', HTML::raw(HTML::image('bar', 'bar')));
```

Just:

``` php
echo HTML::link('foo', HTML::image('bar', 'bar'));
```

And if the user want to show the tag as content he can do this:

``` php
echo e(HTML::image('bar', 'bar')->get());
```

Or:

``` php
echo e( (string) HTML::image('bar', 'bar'));
```

Sorry about my pure English.
