### PR TITLE
Fixes #45

### DIFF
--- a/src/Table/Grid.php
+++ b/src/Table/Grid.php
@@ -34,7 +34,7 @@ class Grid extends BaseGrid implements GridContract
      *
      * @var mixed
      */
-    protected $model;
+    protected $model = [];
 
     /**
      * List of rows in array, is used when model is null.


### PR DESCRIPTION
Having the model defaulted as an array allows it to pass the check as an array on line 441:

https://github.com/orchestral/html/blob/master/src/Table/Grid.php#L441