### PR TITLE
Fix `buildModel()` check

### DIFF
--- a/src/Table/Grid.php
+++ b/src/Table/Grid.php
@@ -411,7 +411,7 @@ class Grid extends BaseGrid implements GridContract
      */
     protected function buildModel($model)
     {
-        if ($this->isEloquentModel($model) && $this->paginate) {
+        if ($this->paginate === true && is_callable([$model, 'paginate'])) {
             $model = $model->paginate($this->perPage, ['*'], $this->pageName);
         } elseif ($this->isQueryBuilder($model)) {
             $model = $model->get();

--- a/src/Table/Grid.php
+++ b/src/Table/Grid.php
@@ -411,7 +411,7 @@ class Grid extends BaseGrid implements GridContract
      */
     protected function buildModel($model)
     {
-        if ($this->paginate === true && method_exists($model, 'paginate')) {
+        if ($this->isEloquentModel($model) && $this->paginate) {
             $model = $model->paginate($this->perPage, ['*'], $this->pageName);
         } elseif ($this->isQueryBuilder($model)) {
             $model = $model->get();

--- a/src/Table/Grid.php
+++ b/src/Table/Grid.php
@@ -411,7 +411,11 @@ class Grid extends BaseGrid implements GridContract
      */
     protected function buildModel($model)
     {
-        if ($this->paginate === true && is_callable([$model, 'paginate'])) {
+        if ($this->isEloquentModel($model)) {
+            $model = $model->getQuery();
+        }
+
+        if ($this->paginate === true && method_exists($model, 'paginate')) {
             $model = $model->paginate($this->perPage, ['*'], $this->pageName);
         } elseif ($this->isQueryBuilder($model)) {
             $model = $model->get();


### PR DESCRIPTION
To my knowledge, only the query builder contains the paginate method, but we can just check if the model is an instance of an eloquent model and paginate it from there.