### PR TITLE
[3.2] Allow data to be retrieved from Eloquent collections for type hinting

### DIFF
--- a/src/Table/Grid.php
+++ b/src/Table/Grid.php
@@ -6,6 +6,7 @@ use Orchestra\Html\Grid as BaseGrid;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Pagination\Paginator;
 use Orchestra\Support\Traits\QueryFilterTrait;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
@@ -445,6 +446,8 @@ class Grid extends BaseGrid implements GridContract
         if ($model instanceof Paginator) {
             $this->setRowsData($model->items());
             $this->paginate = true;
+        } elseif ($model instanceof Collection) {
+            $this->setRowsData($model->all());
         } elseif ($model instanceof Arrayable) {
             $this->setRowsData($model->toArray());
         } elseif (is_array($model)) {


### PR DESCRIPTION
Right now, if you don't want your model paginated, you can't type-hint your models inside column closures.

```php
$column->value = function (Post $post) {};
```

The only work around is by calling the Eloquent collections `all()` method before calling `$table->rows()`.

```php
$posts = Post::where('title', '=', 'First Post')->get();

return Table::of('posts', function () use ($posts) {
    $table->rows($posts);

    $table->column('name', function (Column $column) {
        // Exception is thrown here because the models are turned into arrays.
        $column->value = function (Post $post) {
            //
        };
    });
});
```